### PR TITLE
Implement returnTo navigation

### DIFF
--- a/src/lib/components/ui/common/Header.svelte
+++ b/src/lib/components/ui/common/Header.svelte
@@ -2,20 +2,20 @@
 	import Bell from '@lucide/svelte/icons/bell';
 	import ChevronLeft from '@lucide/svelte/icons/chevron-left';
 
-    import { page } from '$app/state';
+	import { page } from '$app/state';
 
-    const handleBack = (e) => {
-        e.preventDefault();
-        window.history.back();
-    };
+	const handleBack = (e) => {
+		e.preventDefault();
+		window.history.back();
+	};
 </script>
 
 <header class="preset-filled-primary-500 p-4 h-12 flex items-center justify-between">
-    <a href={page.data.referer} class="btn-icon w-6 h-6" onclick={handleBack}>
-        <ChevronLeft class="w-6 h-6" />
-    </a>
-    <h1 class="text-2xl font-semibold uppercase">{page.data.meta?.title ?? 'header'}</h1>
-    <button class="btn-icon w-6 h-6">
-        <Bell class="w-6 h-6" />
-    </button>
+	<a href={page.data.returnTo} class="btn-icon w-6 h-6" onclick={handleBack}>
+		<ChevronLeft class="w-6 h-6" />
+	</a>
+	<h1 class="text-2xl font-semibold uppercase">{page.data.meta?.title ?? 'header'}</h1>
+	<button class="btn-icon w-6 h-6">
+		<Bell class="w-6 h-6" />
+	</button>
 </header>

--- a/src/routes/(main)/category/+page.svelte
+++ b/src/routes/(main)/category/+page.svelte
@@ -1,25 +1,23 @@
 <script>
 	import { page } from '$app/state';
-    import Trash2 from '@lucide/svelte/icons/trash-2';
+	import Trash2 from '@lucide/svelte/icons/trash-2';
 
-    const { data } = $props();
+	const { data } = $props();
 </script>
 
 {#snippet categoryItem(item)}
-    <div class="h-12 preset-filled-surface-500 flex justify-center">
-        <form class="flex-1 content-center"
-            action={page.data.referer}
-        >
-            <button class="w-full text-left px-4">{item.name}</button>
-        </form>
-        <button class="aspect-square btn preset-filled-warning-500">
-            <Trash2 size="32"/>
-        </button>
-    </div>
+	<div class="h-12 preset-filled-surface-500 flex justify-center">
+		<form class="flex-1 content-center" action={page.data.returnTo}>
+			<button class="w-full text-left px-4">{item.name}</button>
+		</form>
+		<button class="aspect-square btn preset-filled-warning-500">
+			<Trash2 size="32" />
+		</button>
+	</div>
 {/snippet}
 
 <div class="p-4 space-y-4">
-    {#each data.categories.content as item}
-        {@render categoryItem(item)}
-    {/each}
+	{#each data.categories.content as item}
+		{@render categoryItem(item)}
+	{/each}
 </div>

--- a/src/routes/+layout.js
+++ b/src/routes/+layout.js
@@ -7,8 +7,12 @@ import { PUBLIC_ZZIC_API_URL } from '$env/static/public';
 export const load = async ({ data, depends, fetch, url }) => {
 	depends('zzic:auth');
 
-    const referer = data.referer || (browser && navigation?.entries()[navigation.currentEntry?.index - 1]?.url);
-	console.log('browser referer:', referer);
+	const returnToParam = url.searchParams.get('returnTo');
+	const returnTo =
+		returnToParam ||
+		data.returnTo ||
+		(browser && navigation?.entries()[navigation.currentEntry?.index - 1]?.url);
+	console.log('browser returnTo:', returnTo);
 
 	const zzic = browser
 		? createZzicBrowserClient(PUBLIC_ZZIC_API_URL, { global: { fetch } })
@@ -23,10 +27,10 @@ export const load = async ({ data, depends, fetch, url }) => {
 		data: { user }
 	} = await zzic.auth.getUser();
 
-	return { 
-		zzic, 
-		user, 
-		referer,
+	return {
+		zzic,
+		user,
+		returnTo,
 		temporal: data.temporal
 	};
 };

--- a/src/routes/+layout.server.js
+++ b/src/routes/+layout.server.js
@@ -1,8 +1,8 @@
 export async function load({ cookies, locals, request }) {
-	const referer = request.headers.get('referer');
+	const returnTo = request.headers.get('referer');
 
 	return {
-		referer,
+		returnTo,
 		temporal: locals.temporal,
 		cookies: cookies.getAll()
 	};


### PR DESCRIPTION
## Summary
- rename `referer` to `returnTo`
- propagate `returnTo` via query parameter or header
- update header and category page to use new field

## Testing
- `pnpm run lint` *(fails: code style issues found)*
- `pnpm run test` *(fails: playwright browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_685eb12f0100832d83b31edf022989ac