### PR TITLE
Fix CalendarWidget story and document tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,4 @@
 | `/auth/sign-out` | 로그아웃  | ✅        | 로그아웃 처리 및 세션 종료      |
 
 인증되지 않은 사용자가 보호된 경로에 접근하면 자동으로 `/auth/sign-in`으로 리다이렉트됩니다.
+\n## Testing\n\nAfter installing dependencies, you need to install the Playwright browsers once:\n\n```sh\npnpm exec playwright install\n```\n\nThen run the test suite with:\n\n```sh\npnpm test\n```\n

--- a/src/stories/CalendarWidget.stories.svelte
+++ b/src/stories/CalendarWidget.stories.svelte
@@ -1,56 +1,54 @@
-<script>
-	import { Meta, Story, Template } from '@storybook/addon-svelte-csf';
-	import CalendarWidget from '$lib/components/calendar/CalendarWidget.svelte';
-	import { mockEvents } from '$lib/types/calendar.js';
+<script module>
+        import { defineMeta } from '@storybook/addon-svelte-csf';
+        import CalendarWidget from '$lib/components/calendar/CalendarWidget.svelte';
+        import { mockEvents } from '$lib/types/calendar.js';
+
+        const { Story } = defineMeta({
+                title: 'Calendar/CalendarWidget',
+                component: CalendarWidget,
+                argTypes: {
+                        events: { control: 'object' },
+                        onEventClick: { action: 'eventClick' },
+                        onViewAll: { action: 'viewAll' }
+                }
+        });
 </script>
 
-<Meta
-	title="Calendar/CalendarWidget"
-	component={CalendarWidget}
-	argTypes={{
-		events: { control: 'object' },
-		onEventClick: { action: 'eventClick' },
-		onViewAll: { action: 'viewAll' }
-	}}
-/>
+<Story name="기본" args={{ events: mockEvents, onEventClick: () => {}, onViewAll: () => {} }}>
+        {#snippet children({ args })}
+                <div class="max-w-sm">
+                        <CalendarWidget {...args} />
+                </div>
+        {/snippet}
+</Story>
 
-<Template let:args>
-	<div class="max-w-sm">
-		<CalendarWidget {...args} />
-	</div>
-</Template>
-
-<Story
-	name="기본"
-	args={{
-		events: mockEvents,
-		onEventClick: () => {},
-		onViewAll: () => {}
-	}}
-/>
+<Story name="이벤트 없음" args={{ events: [], onEventClick: () => {}, onViewAll: () => {} }}>
+        {#snippet children({ args })}
+                <div class="max-w-sm">
+                        <CalendarWidget {...args} />
+                </div>
+        {/snippet}
+</Story>
 
 <Story
-	name="이벤트 없음"
-	args={{
-		events: [],
-		onEventClick: () => {},
-		onViewAll: () => {}
-	}}
-/>
-
-<Story
-	name="많은 이벤트"
-	args={{
-		events: [
-			...mockEvents,
-			...mockEvents.map((event, index) => ({
-				...event,
-				id: `extra-${index}`,
-				title: `추가 이벤트 ${index + 1}`,
-				startDate: new Date(2025, 5, 20 + index)
-			}))
-		],
-		onEventClick: () => {},
-		onViewAll: () => {}
-	}}
-/>
+        name="많은 이벤트"
+        args={{
+                events: [
+                        ...mockEvents,
+                        ...mockEvents.map((event, index) => ({
+                                ...event,
+                                id: `extra-${index}`,
+                                title: `추가 이벤트 ${index + 1}`,
+                                startDate: new Date(2025, 5, 20 + index)
+                        }))
+                ],
+                onEventClick: () => {},
+                onViewAll: () => {}
+        }}
+>
+        {#snippet children({ args })}
+                <div class="max-w-sm">
+                        <CalendarWidget {...args} />
+                </div>
+        {/snippet}
+</Story>


### PR DESCRIPTION
## Summary
- fix `CalendarWidget.stories.svelte` to use `defineMeta` with `<script module>`
- document how to install Playwright browsers before running tests

## Testing
- `pnpm test` *(fails: Vitest caught 17 unhandled errors)*

------
https://chatgpt.com/codex/tasks/task_e_685eb5455900832db83ee962e80b21ef