### PR TITLE
Add categoryId return

### DIFF
--- a/src/routes/(main)/category/+page.svelte
+++ b/src/routes/(main)/category/+page.svelte
@@ -7,9 +7,10 @@
 
 {#snippet categoryItem(item)}
 	<div class="h-12 preset-filled-surface-500 flex justify-center">
-		<form class="flex-1 content-center" action={page.data.returnTo}>
-			<button class="w-full text-left px-4">{item.name}</button>
-		</form>
+       <form class="flex-1 content-center" action={page.data.returnTo}>
+               <input type="hidden" name="categoryId" value={item.id} />
+               <button class="w-full text-left px-4">{item.name}</button>
+       </form>
 		<button class="aspect-square btn preset-filled-warning-500">
 			<Trash2 size="32" />
 		</button>


### PR DESCRIPTION
## Summary
- send selected `categoryId` when returning from the category page

## Testing
- `pnpm test` *(fails: no tests and missing playwright browsers)*
- `pnpm test:e2e` *(fails to start due to missing environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_685eb8be7b88832d936b9aebb65f6225