### PR TITLE
Implement returnTo stack navigation

### DIFF
--- a/src/routes/(consume)/category/+page.svelte
+++ b/src/routes/(consume)/category/+page.svelte
@@ -1,15 +1,20 @@
 <script>
-  import { page } from '$app/state';
-  const { data } = $props();
+	import { page } from '$app/state';
+	const { data } = $props();
+
+	const baseAction = `${page.data.returnTo}${page.data.returnToQuery ? `?${page.data.returnToQuery}` : ''}`;
+	const stackParams = new URLSearchParams(page.data.returnToStack.map((rt) => ['returnTo', rt]));
+	stackParams.append('returnTo', page.url.pathname + page.url.search);
+	const createLink = `/category/create?${stackParams.toString()}`;
 </script>
 
-<form id="category-form" method="get" action={page.data.returnTo} class="p-4 space-y-4">
-  {#each data.categories.content as item (item.id)}
-    <label class="flex items-center gap-2 preset-filled-surface-500 h-12 px-4 rounded">
-      <input type="radio" name="categoryId" value={item.id} class="radio" />
-      <span>{item.name}</span>
-    </label>
-  {/each}
+<form id="category-form" method="get" action={baseAction} class="p-4 space-y-4">
+	{#each data.categories.content as item (item.id)}
+		<label class="flex items-center gap-2 preset-filled-surface-500 h-12 px-4 rounded">
+			<input type="radio" name="categoryId" value={item.id} class="radio" />
+			<span>{item.name}</span>
+		</label>
+	{/each}
 
-  <a href={`/category/create?returnTo=${encodeURIComponent(page.data.returnTo)}`} class="btn preset-filled-primary-500 w-full mt-4">새 카테고리 추가</a>
+	<a href={createLink} class="btn preset-filled-primary-500 w-full mt-4">새 카테고리 추가</a>
 </form>

--- a/src/routes/(consume)/category/create/+page.svelte
+++ b/src/routes/(consume)/category/create/+page.svelte
@@ -1,7 +1,9 @@
 <script>
-  import { page } from '$app/state';
+	import { page } from '$app/state';
+
+	const baseAction = `${page.data.returnTo}${page.data.returnToQuery ? `?${page.data.returnToQuery}` : ''}`;
 </script>
 
-<form id="create-category-form" method="get" action={page.data.returnTo} class="p-4 space-y-4">
-  <input type="text" name="newCategory" placeholder="카테고리 이름" class="input w-full" required />
+<form id="create-category-form" method="get" action={baseAction} class="p-4 space-y-4">
+	<input type="text" name="newCategory" placeholder="카테고리 이름" class="input w-full" required />
 </form>

--- a/src/routes/+layout.js
+++ b/src/routes/+layout.js
@@ -7,12 +7,15 @@ import { PUBLIC_ZZIC_API_URL } from '$env/static/public';
 export const load = async ({ data, depends, fetch, url }) => {
 	depends('zzic:auth');
 
-	const returnToParam = url.searchParams.get('returnTo');
+	const returnToStack = url.searchParams.getAll('returnTo');
 	const returnTo =
-		returnToParam ||
+		returnToStack.at(-1) ||
 		data.returnTo ||
 		(browser && navigation?.entries()[navigation.currentEntry?.index - 1]?.url);
-	console.log('browser returnTo:', returnTo);
+
+	const returnToQueryParams = new URLSearchParams();
+	returnToStack.slice(0, -1).forEach((rt) => returnToQueryParams.append('returnTo', rt));
+	const returnToQuery = returnToQueryParams.toString();
 
 	const zzic = browser
 		? createZzicBrowserClient(PUBLIC_ZZIC_API_URL, { global: { fetch } })
@@ -31,6 +34,8 @@ export const load = async ({ data, depends, fetch, url }) => {
 		zzic,
 		user,
 		returnTo,
+		returnToStack,
+		returnToQuery,
 		temporal: data.temporal
 	};
 };


### PR DESCRIPTION
## Summary
- support stacked `returnTo` query parameters in layout
- compute base action and create link using stacked params in category pages

## Testing
- `npm run lint` *(fails: Many existing lint errors)*
- `npm test` *(fails: e2e tests cannot run)*

------
https://chatgpt.com/codex/tasks/task_e_685f81beaee0832da8c84e8f4cf0b688